### PR TITLE
feat: support tags in slack notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ Type: `string`
 
 The following input variables are optional (have default values):
 
+### action\_slack\_alert\_tags
+
+Description: Event tags to display in slack notifications
+
+Type: `list(string)`
+
+Default: `[]`
+
 ### action\_slack\_channel\_id
 
 Description: The ID of the Slack channel to post events to

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -12,4 +12,5 @@ module "sentry_project" {
   # Extra configuration for the Slack event rule
   action_slack_channel_id   = "C4934F0F3"
   action_slack_workspace_id = "53846"
+  action_slack_alert_tags = ["user"]
 }

--- a/rules.tf
+++ b/rules.tf
@@ -27,7 +27,7 @@ resource "sentry_rule" "slack_notification" {
       channel_id = var.action_slack_channel_id
       id         = "sentry.integrations.slack.notify_action.SlackNotifyServiceAction"
       name       = "Send a notification to the Mixmax Slack workspace to #sentry and show tags [] in notification"
-      tags       = ""
+      tags       = join(",", var.action_slack_alert_tags)
       workspace  = var.action_slack_workspace_id
     }
   ]

--- a/variables.tf
+++ b/variables.tf
@@ -64,3 +64,9 @@ variable "action_slack_workspace_id" {
   type        = string
   default     = ""
 }
+
+variable "action_slack_alert_tags" {
+  description = "Event tags to display in slack notifications"
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
Adds variable to configure event tags to include in slack notifications.